### PR TITLE
base: Add Multi usb controller for Asus devices 

### DIFF
--- a/core/res/res/values/voltage_config.xml
+++ b/core/res/res/values/voltage_config.xml
@@ -194,5 +194,8 @@
 
      <!-- Whether to show Refresh Rate Tile or Not (Only For High Refresh Rate Devices) -->
      <bool name="config_showRefreshRateTile">true</bool>
+     
+     <!-- Switch USB controller on Asus ROG devices-->
+     <bool name="config_switchUsbController">false</bool>
 
 </resources>

--- a/core/res/res/values/voltage_symbols.xml
+++ b/core/res/res/values/voltage_symbols.xml
@@ -189,5 +189,9 @@
 
     <!-- Lock gesture -->
     <java-symbol type="string" name="gesture_locked_warning" />
+     
+    <!-- Switch USB controller on Asus ROG devices-->
+    <java-symbol type="bool" name="config_switchUsbController" />
+</resources>
 
 </resources>

--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
@@ -211,6 +211,16 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
 
     private static Set<Integer> sDenyInterfaces;
     private HashMap<Long, FileDescriptor> mControlFds;
+    
+     /* Omni add-on */
+    private static boolean mUseMultiUsbController;
+    private static String udc_change;
+    private static final long FUNCTION_UDC_SWITCH = 128;
+    private static final String USB_CONTROLLER_PROPERTY = "sys.usb.controller";
+    private static final String UDC1_MODE = "/sys/devices/platform/soc/a600000.ssusb/mode";
+    private static final String UDC2_MODE = "/sys/devices/platform/soc/a800000.ssusb/mode";
+    private static final String UDC1_NAME_MATCH = "DEVPATH=/devices/platform/soc/a600000.ssusb/a600000.dwc3";
+    private static final String UDC2_NAME_MATCH = "DEVPATH=/devices/platform/soc/a800000.ssusb/a800000.dwc3";
 
     static {
         sDenyInterfaces = new HashSet<>();
@@ -252,7 +262,18 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
                 if (DEBUG) Slog.d(TAG, "got accessory start");
                 mHandler.removeMessages(MSG_ACCESSORY_HANDSHAKE_TIMEOUT);
                 mHandler.setStartAccessoryTrue();
-                startAccessoryMode();
+                startAccessoryMode();    
+            }
+            if (mUseMultiUsbController) {
+                String udcname = event.get("UDC_NAME");
+                if (udcname != null) {
+                    String controller = SystemProperties.get(USB_CONTROLLER_PROPERTY);
+                    if (!controller.equals(udcname)) {
+                        String unused = udc_change = udcname;
+                        setCurrentFunctions(FUNCTION_UDC_SWITCH);
+                    }
+                    Slog.i(TAG, "Controller=" + controller + " UDC_NAME=" + udcname);
+                }
             }
         }
     }
@@ -381,11 +402,20 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
 
         mContext.registerReceiver(languageChangedReceiver,
                 new IntentFilter(Intent.ACTION_LOCALE_CHANGED));
+        
+        mUseMultiUsbController = mContext.getResources().getBoolean(
+                                    com.android.internal.R.bool.config_switchUsbController);
+
+
 
         // Watch for USB configuration changes
         mUEventObserver = new UsbUEventObserver();
         mUEventObserver.startObserving(USB_STATE_MATCH);
         mUEventObserver.startObserving(ACCESSORY_START_MATCH);
+        if (mUseMultiUsbController) {
+            mUEventObserver.startObserving(UDC1_NAME_MATCH);
+            mUEventObserver.startObserving(UDC2_NAME_MATCH);
+        }
     }
 
     UsbProfileGroupSettingsManager getCurrentSettings() {
@@ -1008,6 +1038,20 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
                     break;
                 case MSG_SET_CURRENT_FUNCTIONS:
                     long functions = (Long) msg.obj;
+                    if (mUseMultiUsbController) {
+                        if (FUNCTION_UDC_SWITCH == functions) {
+                            SystemProperties.set(USB_CONTROLLER_PROPERTY, udc_change);
+                            if (!mScreenLocked) {
+                                long unlockfunctions = mScreenUnlockedFunctions;
+                                if (unlockfunctions != 0) {
+                                    setEnabledFunctions(unlockfunctions, true);
+                                    break;
+                                }
+                            }
+                            setEnabledFunctions(0, true);
+                            break;
+                        }
+                    }
                     setEnabledFunctions(functions, false);
                     break;
                 case MSG_SET_SCREEN_UNLOCKED_FUNCTIONS:
@@ -1121,15 +1165,38 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
 
         protected void finishBoot() {
             if (mBootCompleted && mCurrentUsbFunctionsReceived && mSystemReady) {
+                boolean switchudc = false
                 if (mPendingBootBroadcast) {
                     updateUsbStateBroadcastIfNeeded(getAppliedFunctions(mCurrentFunctions));
                     mPendingBootBroadcast = false;
+                }
+                if (mUseMultiUsbController) {
+                    String controller = SystemProperties.get(USB_CONTROLLER_PROPERTY);
+                    try {
+                        String usb1mode = FileUtils.readTextFile(new File(UDC1_MODE), 0, null).trim();
+                        String usb2mode = FileUtils.readTextFile(new File(UDC2_MODE), 0, null).trim();
+                        if ("peripheral".equals(usb1mode) && !"a600000.dwc3".equals(controller)) {
+                            switchudc = true;
+                            SystemProperties.set(USB_CONTROLLER_PROPERTY, "a600000.dwc3");
+                        } else if ("peripheral".equals(usb2mode) && !"a800000.dwc3".equals(controller)) {
+                            switchudc = true;
+                            SystemProperties.set(USB_CONTROLLER_PROPERTY, "a800000.dwc3");
+                        }
+                        String str = TAG;
+                        Slog.i(str, "usb1_mode=" + usb1mode + " usb2_mode=" + usb2mode + " controller=" + controller);
+                    } catch (IOException e) {
+                        Slog.e(TAG, "Error read usb mode", e);
+                    }
                 }
                 if (!mScreenLocked
                         && mScreenUnlockedFunctions != UsbManager.FUNCTION_NONE) {
                     setScreenUnlockedFunctions();
                 } else {
-                    setEnabledFunctions(UsbManager.FUNCTION_NONE, false);
+                    if (mUseMultiUsbController) {
+                        setEnabledFunctions(UsbManager.FUNCTION_NONE, switchudc);
+                    } else {
+                        setEnabledFunctions(UsbManager.FUNCTION_NONE, false);
+                    }
                 }
                 if (mCurrentAccessory != null) {
                     mUsbDeviceManager.getCurrentSettings().accessoryAttached(mCurrentAccessory);


### PR DESCRIPTION
All ROG devices have 2 usb port. We can use both for mtp, not only charger.

All credits goes to @micky387 for making this happen.