### PR TITLE
fwb: Add missing android.permission.REGISTER_STATS_PULL_ATOM

### DIFF
--- a/data/etc/com.android.launcher3.xml
+++ b/data/etc/com.android.launcher3.xml
@@ -27,5 +27,6 @@
         <permission name="android.permission.STOP_APP_SWITCHES"/>
         <permission name="android.permission.FORCE_STOP_PACKAGES"/>
         <permission name="android.permission.MANAGE_PARALLEL_SPACES" />
+        <permission name="android.permission.REGISTER_STATS_PULL_ATOM" />
     </privapp-permissions>
 </permissions>

--- a/data/etc/privapp-permissions-platform.xml
+++ b/data/etc/privapp-permissions-platform.xml
@@ -53,6 +53,7 @@ applications that come with the platform
     <privapp-permissions package="com.android.launcher3">
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
         <permission name="android.permission.FORCE_STOP_PACKAGES"/>
+        <permission name="android.permission.REGISTER_STATS_PULL_ATOM"/>
     </privapp-permissions>
 
     <privapp-permissions package="com.android.location.fused">


### PR DESCRIPTION
launcher3 permission

 * Fixes

------ beginning of crash 02-07 13:32:34.640 1020 1020 E AndroidRuntime: *** FATAL EXCEPTION IN SYSTEM PROCESS: main 02-07 13:32:34.640 1020 1020 E AndroidRuntime: java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions allowlist: {com.android.launcher3 (/system_ext/priv-app/Launcher3QuickStep): android.permission.REGISTER_STATS_PULL_ATOM}

Signed-off-by: karthik1896 <karthik1896@outlook.com>